### PR TITLE
Add customise viz and fix self bug in presence plot

### DIFF
--- a/Metrica_Viz.py
+++ b/Metrica_Viz.py
@@ -13,10 +13,8 @@ https://github.com/Friends-of-Tracking-Data-FoTD/LaurieOnTracking
 """
 
 import matplotlib.pyplot as plt
-import matplotlib as mpl
 import numpy as np
 import matplotlib.animation as animation
-import Metrica_PitchControl as mpc
 from matplotlib.colors import LinearSegmentedColormap
 
 
@@ -481,7 +479,7 @@ def plot_pitchcontrol_for_event(
     player_id=0,
     player_x_velocity=0,
     player_y_velocity=0,
-    cmap_list = [],
+    cmap_list=[],
     alpha_pitch_control=0.5,
     team_colors=("r", "b")
 ):
@@ -557,27 +555,26 @@ def plot_pitchcontrol_for_event(
     if plotting_difference:
         PPCF = convert_pitch_control_for_cmap(PPCF)
 
-    reds_cmap = 'Reds'
-    blues_cmap = 'Blues'
+    home_presence_cmap = 'Reds'
+    away_presence_cmap = 'Blues'
+
     home_cmap = 'bwr'
     away_cmap = 'bwr_r'
 
-
     if len(cmap_list):
-        blues_cmap = LinearSegmentedColormap.from_list("", cmap_list[:6][::-1])
-        reds_cmap = LinearSegmentedColormap.from_list("", cmap_list[6:])
+        home_presence_cmap = LinearSegmentedColormap.from_list("", cmap_list[len(cmap_list) // 2:])
+        away_presence_cmap = LinearSegmentedColormap.from_list("", cmap_list[:len(cmap_list) // 2][::-1])
         home_cmap = LinearSegmentedColormap.from_list("", cmap_list)
         away_cmap = LinearSegmentedColormap.from_list("", cmap_list[::-1])
-
 
     # If we are plotting a player's space captured, apply a specific cmap
     if plotting_presence:
         if team_to_plot != possession_team:
             PPCF = -1 * PPCF
         if team_to_plot == "Home":
-            cmap = reds_cmap
+            cmap = home_presence_cmap
         else:
-            cmap = blues_cmap
+            cmap = away_presence_cmap
 
     # Otherwise, apply the default heatmap from the original function
     else:

--- a/Metrica_Viz.py
+++ b/Metrica_Viz.py
@@ -185,6 +185,7 @@ def plot_frame(
     figax=None,
     team_colors=("r", "b"),
     field_dimen=(106.0, 68.0),
+    field_color="green",
     include_player_velocities=False,
     PlayerMarkerSize=10,
     PlayerAlpha=0.7,
@@ -201,6 +202,7 @@ def plot_frame(
         fig,ax: Can be used to pass in the (fig,ax) objects of a previously generated pitch. Set to (fig,ax) to use an existing figure, or None (the default) to generate a new pitch plot,
         team_colors: Tuple containing the team colors of the home & away team. Default is 'r' (red, home team) and 'b' (blue away team)
         field_dimen: tuple containing the length and width of the pitch in meters. Default is (106,68)
+        field_color: color of field. options are {'green','white'}
         include_player_velocities: Boolean variable that determines whether player velocities are also plotted (as quivers). Default is False
         PlayerMarkerSize: size of the individual player marlers. Default is 10
         PlayerAlpha: alpha (transparency) of player markers. Defaault is 0.7
@@ -212,7 +214,7 @@ def plot_frame(
 
     """
     if figax is None:  # create new pitch
-        fig, ax = plot_pitch(field_dimen=field_dimen)
+        fig, ax = plot_pitch(field_color=field_color, field_dimen=field_dimen)
     else:  # overlay on a previously generated pitch
         fig, ax = figax  # unpack tuple
     # plot home & away teams in order
@@ -285,6 +287,7 @@ def save_match_clip(
     frames_per_second=25,
     team_colors=("r", "b"),
     field_dimen=(106.0, 68.0),
+    field_color="white",
     include_player_velocities=False,
     PlayerMarkerSize=10,
     PlayerAlpha=0.7,
@@ -303,6 +306,7 @@ def save_match_clip(
         frames_per_second: frames per second to assume when generating the movie. Default is 25.
         team_colors: Tuple containing the team colors of the home & away team. Default is 'r' (red, home team) and 'b' (blue away team)
         field_dimen: tuple containing the length and width of the pitch in meters. Default is (106,68)
+        field_color: color of field. options are {'green','white'}
         include_player_velocities: Boolean variable that determines whether player velocities are also plotted (as quivers). Default is False
         PlayerMarkerSize: size of the individual player marlers. Default is 10
         PlayerAlpha: alpha (transparency) of player markers. Defaault is 0.7
@@ -327,7 +331,7 @@ def save_match_clip(
     fname = fpath + "/" + fname + ".mp4"  # path and filename
     # create football pitch
     if figax is None:
-        fig, ax = plot_pitch(field_dimen=field_dimen)
+        fig, ax = plot_pitch(field_color=field_color, field_dimen=field_dimen)
     else:
         fig, ax = figax
     fig.set_tight_layout(True)
@@ -405,6 +409,7 @@ def plot_events(
     events,
     figax=None,
     field_dimen=(106.0, 68),
+    field_color="green",
     indicators=["Marker", "Arrow"],
     color="r",
     marker_style="o",
@@ -420,6 +425,7 @@ def plot_events(
         events: row (i.e. instant) of the home team tracking data frame
         fig,ax: Can be used to pass in the (fig,ax) objects of a previously generated pitch. Set to (fig,ax) to use an existing figure, or None (the default) to generate a new pitch plot,
         field_dimen: tuple containing the length and width of the pitch in meters. Default is (106,68)
+        field_color: color of field. options are {'green','white'}
         indicators: List containing choices on how to plot the event. 'Marker' places a marker at the 'Start X/Y' location of the event; 'Arrow' draws an arrow from the start to end locations. Can choose one or both.
         color: color of indicator. Default is 'r' (red)
         marker_style: Marker type used to indicate the event position. Default is 'o' (filled ircle).
@@ -433,7 +439,7 @@ def plot_events(
     """
 
     if figax is None:  # create new pitch
-        fig, ax = plot_pitch(field_dimen=field_dimen)
+        fig, ax = plot_pitch(field_color=field_color, field_dimen=field_dimen)
     else:  # overlay on a previously generated pitch
         fig, ax = figax
     for i, row in events.iterrows():
@@ -481,7 +487,8 @@ def plot_pitchcontrol_for_event(
     player_y_velocity=0,
     cmap_list=[],
     alpha_pitch_control=0.5,
-    team_colors=("r", "b")
+    team_colors=("r", "b"),
+    field_color="white"
 ):
     """ plot_pitchcontrol_for_event( event_id, events,  tracking_home, tracking_away, PPCF, xgrid, ygrid )
 
@@ -504,6 +511,7 @@ def plot_pitchcontrol_for_event(
         cmap_list: List of colors to use in the pitch control spaces for each team. Default is an empty list.
         alpha_pitch_control: alpha (transparency) of spaces heatmap. Default is 0.5
         team_colors: Tuple containing the team colors of the home & away team. Default is 'r' (red, home team) and 'b' (blue away team)
+        field_color: color of the field. Default is green.
 
     Returrns
     -----------
@@ -517,7 +525,7 @@ def plot_pitchcontrol_for_event(
     possession_team = events.loc[event_id].Team
 
     # plot frame and event
-    fig, ax = plot_pitch(field_color="white", field_dimen=field_dimen)
+    fig, ax = plot_pitch(field_color=field_color, field_dimen=field_dimen)
     plot_frame(
         tracking_home.loc[event_frame],
         tracking_away.loc[event_frame],

--- a/PlayerPitchControlAnalysis.py
+++ b/PlayerPitchControlAnalysis.py
@@ -17,6 +17,7 @@ class PlayerPitchControlAnalysisPlayer(object):
         player_to_analyze,
         field_dimens=(106.0, 68.0),
         n_grid_cells_x=50,
+
     ):
         """
         This class is used to consolidate many of the functions that would be used to analyze the impact of an
@@ -67,6 +68,8 @@ class PlayerPitchControlAnalysisPlayer(object):
         :param tuple field_dimens: tuple containing the length and width of the pitch in meters. Default is (106,68)
         :param int n_grid_cells_x: Number of pixels in the grid (in the x-direction) that covers the surface.
                 Default is 50. n_grid_cells_y will be calculated based on n_grid_cells_x and the field dimensions
+
+
         """
         self.tracking_home = tracking_home
         self.tracking_away = tracking_away
@@ -493,6 +496,10 @@ class PlayerPitchControlAnalysisPlayer(object):
         relative_y_change=0,
         replace_velocity=False,
         replace_function="movement",
+        cmap_list=[],
+        alpha=0.7,
+        alpha_pitch_control=0.5,
+        team_colors=("r", "b")
     ):
         """
         Function description:
@@ -534,6 +541,12 @@ class PlayerPitchControlAnalysisPlayer(object):
             Must be either "movement", "presence" or "location". Defaults to "movement". For a detailed description of
             this argument, please refer to the docstring in ``calculate_pitch_control_difference``.
 
+        :param list cmap_list: List of colors to use in the pitch control spaces for each team. Default is an empty list.
+        :param float alpha: alpha (transparency) of player markers. Default is 0.7
+        :param float alpha_pitch_control: alpha (transparency) of spaces heatmap. Default is 0.5
+        :param tuple team_colors: Tuple containing the team colors of the home & away team. Default is 'r' (red, home team) and 'b' (blue away team)
+
+
         Returns:
             This function technically does not return anything, but does produce a matplotlib plot.
         """
@@ -562,8 +575,14 @@ class PlayerPitchControlAnalysisPlayer(object):
                 ygrid=ygrid,
                 plotting_presence=True,
                 team_to_plot=self.team_player_to_analyze,
+                alpha=alpha,
+                alpha_pitch_control=alpha_pitch_control,
+                cmap_list=cmap_list,
+                team_colors=team_colors
+
             )
         elif replace_function == "movement":
+
             mviz.plot_pitchcontrol_for_event(
                 event_id=self.event_id,
                 events=self.events,
@@ -574,6 +593,10 @@ class PlayerPitchControlAnalysisPlayer(object):
                 xgrid=xgrid,
                 ygrid=ygrid,
                 plotting_difference=True,
+                alpha=alpha,
+                alpha_pitch_control=alpha_pitch_control,
+                cmap_list=cmap_list,
+                team_colors=team_colors
             )
         elif replace_function == "location":
             event_frame = self.events.loc[self.event_id]["Start Frame"]
@@ -634,6 +657,10 @@ class PlayerPitchControlAnalysisPlayer(object):
                 player_y_coordinate=y_coordinate,
                 player_x_velocity=replace_x_velocity,
                 player_y_velocity=replace_y_velocity,
+                alpha=alpha,
+                alpha_pitch_control=alpha_pitch_control,
+                cmap_list=cmap_list,
+                team_colors=team_colors
             )
         if replace_function == "movement":
             plt.title(


### PR DESCRIPTION
No changes were made to calculations. I've only changed viz things and one little bug in PlayerPitchControlAnalysis.py.
1. Fixed little bug in plot_pitch_control_difference function. The argument team_player_to_analyze in mviz.plotpitchcontrol_for_event in the conditional of replace_function = 'presence'  was lacking a self.
2. Add viz customizations in Metrica_Viz.py but were extended to PlayerPitchControlAnalysis.py): 
a. implementing cmap lists in case we want to make a custom cmap.
b. Adjusted code to be able to select hexadecimal colors to team_colors.
c.  Be able to customise the transparency of the space control shadows.